### PR TITLE
chat-spaceのデータベース設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,55 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## users_groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+|email|string|null: false, unique: true|
+|encrypted_password|string|null: false, unique: true
+|reset_password_token|string|
+|reset_password_sent_at|string|
+|remember_created_at|string|
+
+### Association
+- devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+- has_many :messages
+- has_many :groups, through: :users_groups
+
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string|
+|user|references|forenign_key: true|
+|group|references|forenign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|unique: true|
+
+### Association
+- has_many :messages
+- has_many :users, through: :users_groups
+

--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ Things you may want to cover:
 - devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 - has_many :messages
+- has_many :users_groups
 - has_many :groups, through: :users_groups
 
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text|
 |image|string|
 |user|references|forenign_key: true|
 |group|references|forenign_key: true|
@@ -72,5 +73,6 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
+- has_many :users_groups
 - has_many :users, through: :users_groups
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|unique: true|
+|name|string|null: false|unique: true|
 
 ### Association
 - has_many :messages

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Things you may want to cover:
 |remember_created_at|string|
 
 ### Association
-- devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
 - has_many :messages
 - has_many :users_groups
 - has_many :groups, through: :users_groups

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,5 @@
 class Group < ApplicationRecord
   has_many :messages
+  has_many :users_groups
   has_many :users, through: :users_groups
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,10 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise  ：database_authenticatable 、 ：registerable 、
+  ：recoverable 、 ：rememberable 、 ：validatable
   has_many :messages
   has_many :users_groups
   has_many :groups, through: :users_groups
 end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :messages
+  has_many :users_groups
   has_many :groups, through: :users_groups
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,6 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
   has_many :messages
   has_many :users_groups
   has_many :groups, through: :users_groups

--- a/db/migrate/20200711084320_devise_create_users.rb
+++ b/db/migrate/20200711084320_devise_create_users.rb
@@ -37,7 +37,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
       t.timestamps null: false
     end
 
-    add_index :users, :name                  unique: true
+    add_index :users, :name,                 unique: true
     add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true

--- a/db/migrate/20200711084921_create_messages.rb
+++ b/db/migrate/20200711084921_create_messages.rb
@@ -1,7 +1,7 @@
 class CreateMessages < ActiveRecord::Migration[6.0]
   def change
     create_table :messages do |t|
-      t.text :body, null: false
+      t.text :body
       t.string :image
       t.references :user, forenign_key: true
       t.references :group, forenign_key: true

--- a/db/migrate/20200711085138_create_groups.rb
+++ b/db/migrate/20200711085138_create_groups.rb
@@ -1,7 +1,7 @@
 class CreateGroups < ActiveRecord::Migration[6.0]
   def change
     create_table :groups do |t|
-      t.string :name
+      t.string :name, null: false
       t.timestamps
     end
     add_index :groups, :name, unique: true

--- a/db/migrate/20200711100127_create_users_groups.rb
+++ b/db/migrate/20200711100127_create_users_groups.rb
@@ -1,8 +1,8 @@
 class CreateUsersGroups < ActiveRecord::Migration[6.0]
   def change
     create_table :users_groups do |t|
-      t.references :user, forenign_key: true
-      t.references :group, forenign_key: true
+      t.references :user, null: false, forenign_key: true
+      t.references :group, null: false, forenign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2020_07_11_102106) do
   end
 
   create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "body", null: false
+    t.text "body"
     t.string "image"
     t.bigint "user_id"
     t.bigint "group_id"
@@ -42,8 +42,8 @@ ActiveRecord::Schema.define(version: 2020_07_11_102106) do
   end
 
   create_table "users_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "group_id"
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["group_id"], name: "index_users_groups_on_group_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,8 +39,6 @@ ActiveRecord::Schema.define(version: 2020_07_11_102106) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "name"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "users_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2020_07_11_102106) do
 
   create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_groups_on_name", unique: true


### PR DESCRIPTION
What：chat-spaceのアプリケーション作成にあたり、データベースの設計を行った。users・messages・groups・users_groupsの4つのテーブルを作成した。また、READMEにデータベースの設定を記載した。

Why：chat-spaceにはユーザー管理機能、グループ機能・メッセージの投稿機能があり、データベースには上記4つのテーブルが必要と考えるため。これらのデータベースを実装することにより、登録したユーザーでのメッセージやグループ内でのメッセージが残る。

確認をお願い致します。